### PR TITLE
uri 일괄 수정 및 예전 코드 수정

### DIFF
--- a/src/main/java/hidn/navada/exchange/ExchangeController.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeController.java
@@ -15,8 +15,8 @@ public class ExchangeController {
 
 
     // 교환 완료
-    @PatchMapping(value = "/user/exchange/{exchangeId}")
-    public SingleResponse<Exchange> completeExchange(@PathVariable Long exchangeId, @RequestParam(name="acceptoryn") Boolean isAcceptor){
+    @PatchMapping(value = "/exchange/{exchangeId}")
+    public SingleResponse<Exchange> completeExchange(@PathVariable Long exchangeId, @RequestParam Boolean isAcceptor){
         return responseService.getSingleResponse(exchangeService.completeExchange(exchangeId, isAcceptor));
     }
 
@@ -27,14 +27,14 @@ public class ExchangeController {
     }
 
     // 교환상대에게 평점 부여
-    @PatchMapping(value = "/user/exchange/{exchangeId}/rate")
-    public SingleResponse<Exchange> rateExchange(@PathVariable Long exchangeId, @RequestParam(name="acceptoryn") Boolean isAcceptor, @RequestParam(name="rating") float rating){
+    @PatchMapping(value = "/exchange/{exchangeId}/rate")
+    public SingleResponse<Exchange> rateExchange(@PathVariable Long exchangeId, @RequestParam Boolean isAcceptor, @RequestParam float rating){
         return responseService.getSingleResponse(exchangeService.rateExchange(exchangeId, isAcceptor, rating));
     }
 
     // 교환내역 삭제 api
-    @PatchMapping(value = "/user/exchange/{exchangeId}/delete")
-    public SingleResponse<Exchange> deleteExchangeHistory(@PathVariable Long exchangeId, @RequestParam(name="acceptoryn") Boolean isAcceptor){
+    @PatchMapping(value = "/exchange/{exchangeId}/delete")
+    public SingleResponse<Exchange> deleteExchangeHistory(@PathVariable Long exchangeId, @RequestParam Boolean isAcceptor){
         return responseService.getSingleResponse(exchangeService.deleteExchangeHistory(exchangeId, isAcceptor));
     }
 }

--- a/src/main/java/hidn/navada/exchange/ExchangeService.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeService.java
@@ -26,16 +26,14 @@ public class ExchangeService {
 
     //교환 성립
     public Exchange createExchange(Request request) {
-        Exchange exchange = new Exchange();
+        Exchange exchange = Exchange.builder()
+                .acceptor(request.getAcceptor())
+                .acceptorProduct(request.getAcceptorProduct())
+                .requester(request.getRequester())
+                .requesterProduct(request.getRequesterProduct())
+                .build();
 
-        exchange.setAcceptor(request.getAcceptor());
-        exchange.setAcceptorProduct(request.getAcceptorProduct());
-        exchange.setRequester(request.getRequester());
-        exchange.setRequesterProduct(request.getRequesterProduct());
-
-        exchangeJpaRepo.save(exchange);
-
-        return exchange;
+        return exchangeJpaRepo.save(exchange);
     }
 
     //교환 완료
@@ -62,13 +60,8 @@ public class ExchangeService {
             acceptorProduct.setProductStatusCd(2);
             requesterProduct.setProductStatusCd(2);
 
-            productJpaRepo.save(acceptorProduct);
-            productJpaRepo.save(requesterProduct);
-
             updateUserInfo(exchange);
         }
-
-        exchangeJpaRepo.save(exchange);
 
         return exchange;
     }
@@ -126,8 +119,6 @@ public class ExchangeService {
             exchange.setAcceptorRating(rating);
         }
 
-        exchangeJpaRepo.save(exchange);
-
         return exchange;
     }
 
@@ -142,8 +133,6 @@ public class ExchangeService {
             // 요청자가 교환 내역을 삭제하려는 경우
             exchange.setRequesterHistoryDeleteYn(true);
         }
-
-        exchangeJpaRepo.save(exchange);
 
         return exchange;
     }

--- a/src/main/java/hidn/navada/exchange/request/RequestController.java
+++ b/src/main/java/hidn/navada/exchange/request/RequestController.java
@@ -18,14 +18,13 @@ public class RequestController {
     private final RequestService requestService;
 
     // 교환신청 등록
-    @PostMapping(value = "/user/{userId}/exchange/{requestProductId}/request/{acceptorProductId}")
-    public SingleResponse<Request> createRequest(@PathVariable Long userId, @PathVariable Long requestProductId, @PathVariable Long acceptorProductId){
-        // userId 필요?, params로 받을지 pathvariable로 받을지
-        return responseService.getSingleResponse(requestService.createRequest(userId, requestProductId, acceptorProductId));
+    @PostMapping(value = "/exchange/request/{requesterProductId}/{acceptorProductId}")
+    public SingleResponse<Request> createRequest(@PathVariable Long requesterProductId, @PathVariable Long acceptorProductId){
+        return responseService.getSingleResponse(requestService.createRequest(requesterProductId, acceptorProductId));
     }
 
     // 교환신청 수락
-    @PatchMapping(value = "/user/exchange/request/{requestId}")
+    @PatchMapping(value = "/exchange/request/{requestId}")
     public SingleResponse<Exchange> createRequest(@PathVariable Long requestId){
         return responseService.getSingleResponse(requestService.acceptRequest(requestId));
     }
@@ -58,12 +57,10 @@ public class RequestController {
     }
 
     // 교환신청 취소
-    @DeleteMapping(value="/user/exchange/request/{requestId}")
+    @DeleteMapping(value="/exchange/request/{requestId}")
     public CommonResponse deleteRequest(@PathVariable Long requestId){
-        if(requestService.deleteRequest(requestId))
-            return responseService.getSuccessResponse();
-        else
-            return responseService.getErrorResponse(-1, "FAIL: 교환신청 상태가 대기중이 아닙니다.");
+        requestService.deleteRequest(requestId);
+        return responseService.getSuccessResponse();
     }
 
     //교환신청 거절

--- a/src/main/java/hidn/navada/heart/HeartController.java
+++ b/src/main/java/hidn/navada/heart/HeartController.java
@@ -15,7 +15,7 @@ public class HeartController {
     private final HeartService heartService;
 
     //좋아요 등록
-    @PostMapping(value = "/heart/{productId}")
+    @PostMapping(value = "/product/{productId}/heart")
     public SingleResponse<Heart> saveHeart(@PathVariable long productId, @RequestParam long userId){
         return responseService.getSingleResponse(heartService.saveHeart(productId, userId));
     }
@@ -28,7 +28,7 @@ public class HeartController {
     }
 
     //사용자별 좋아요 목록 조회
-    @GetMapping(value = "/hearts/{userId}")
+    @GetMapping(value = "/user/{userId}/hearts")
     public ListResponse<Heart> getHeartsByUser(@PathVariable long userId){
         return responseService.getListResponse(heartService.getHeartsByUser(userId));
     }

--- a/src/main/java/hidn/navada/product/ProductController.java
+++ b/src/main/java/hidn/navada/product/ProductController.java
@@ -15,7 +15,7 @@ public class ProductController {
     private final ResponseService responseService;
 
     //상품 등록
-    @PostMapping(value="/product/{userId}")
+    @PostMapping(value="/user/{userId}/product")
     public SingleResponse<Product> saveProduct(@PathVariable long userId, @ModelAttribute ProductParams productParams){
         return responseService.getSingleResponse(productService.createProduct(userId, productParams));
     }
@@ -27,7 +27,7 @@ public class ProductController {
     }
 
     //사용자별 상품 리스트 조회
-    @GetMapping(value = "/products/{userId}")
+    @GetMapping(value = "/user/{userId}/products")
     public ListResponse<Product> getProductsByUser(@PathVariable long userId){
         return responseService.getListResponse(productService.getProductsByUser(userId));
     }


### PR DESCRIPTION
전에 결정한 방식으로 uri를 일괄 수정했습니다!

추가적으로 예전에 작성한 코드를 다음과 같이 수정했습니다.
1. uri에 대문자를 지양하라해서 @RequestParam을 낙타케이스로 쓰지 않았는데, 이는 찾아보니 써도 된다 아니다 말이 많더군요...
   일단 네이버를 비롯한 많은 회사들이 사용하는 것을 보고 저도 통일감있게 보기 편하고자 그냥 변수와 같게 수정했습니당!
2. 객체 생성시 builder()로 생성하게 수정했습니다
3. 불필요한 jpaRepo.save()를 삭제했습니다
4. 교환신청등록 uri를 수정해봤는데 이부분은 api로 파라미터를 어떻게 받는게 좋을지 잘 모르겠어서 일단 보이시는 것처럼 수정했습니다..
    userId는 사용하고 있지 않아서 삭제했습니다
5. 교환신청삭제 exception handling을 수정했습니다

어떤 것이든 더 나은 방법이 있거나 수정할 부분이 있다면 작은거라도 알려주시면 감사하겠습니당!!