### PR TITLE
회원 단건 조회 api 생성

### DIFF
--- a/src/main/java/hidn/navada/product/ProductService.java
+++ b/src/main/java/hidn/navada/product/ProductService.java
@@ -2,11 +2,8 @@ package hidn.navada.product;
 
 import hidn.navada.comm.exception.CategoryNotFoundException;
 import hidn.navada.comm.exception.ProductNotFoundException;
-import hidn.navada.comm.exception.ProductStatusCdDiscrepancyException;
 import hidn.navada.comm.exception.UserNotFoundException;
 
-import hidn.navada.heart.HeartJpaRepo;
-import hidn.navada.exchange.request.RequestJpaRepo;
 import hidn.navada.product.category.Category;
 import hidn.navada.product.category.CategoryJpaRepo;
 import hidn.navada.user.User;
@@ -32,7 +29,6 @@ public class ProductService {
     private final ProductJpaRepo productJpaRepo;
     private final CategoryJpaRepo categoryJpaRepo;
     private final UserJpaRepo userJpaRepo;
-    private final HeartJpaRepo heartJpaRepo;
 
     //상품 등록
     public Product createProduct(long userId, ProductParams productParams){

--- a/src/main/java/hidn/navada/user/User.java
+++ b/src/main/java/hidn/navada/user/User.java
@@ -1,5 +1,6 @@
 package hidn.navada.user;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import hidn.navada.comm.BaseTime;
 import hidn.navada.comm.enums.UserLevel;
 import lombok.*;
@@ -23,6 +24,7 @@ public class User extends BaseTime {
 
     private String userEmail;       // 회원 이메일
 
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     private String userPassword;    // 회원 비밀번호
 
     private String userPhoneNum;    // 회원 전화번호

--- a/src/main/java/hidn/navada/user/UserController.java
+++ b/src/main/java/hidn/navada/user/UserController.java
@@ -1,6 +1,10 @@
 package hidn.navada.user;
 
+import hidn.navada.comm.response.ResponseService;
+import hidn.navada.comm.response.SingleResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -8,5 +12,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping(value = "/v1")
 public class UserController {
+    private final UserService userService;
+    private final ResponseService responseService;
 
+    // 회원 단건 조회
+    @GetMapping(value = "/user/{userId}")
+    public SingleResponse<User> getUser(@PathVariable long userId){
+        return responseService.getSingleResponse(userService.getOneUser(userId));
+    }
 }

--- a/src/main/java/hidn/navada/user/UserService.java
+++ b/src/main/java/hidn/navada/user/UserService.java
@@ -1,9 +1,16 @@
 package hidn.navada.user;
 
+import hidn.navada.comm.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+    private final UserJpaRepo userJpaRepo;
+
+    // 회원 단건 조회
+    public User getOneUser(long userId){
+        return userJpaRepo.findById(userId).orElseThrow(UserNotFoundException::new);
+    }
 }


### PR DESCRIPTION
회원 단건 조회 api를 생성했습니다!

만들다보니 유저객체에 비밀번호가 포함되어있어서 보안상 DTO를 만드는게 나을까하는 생각이 들었어요. 그리고 상품 상세 페이지에서 유저 개인정보까지 포함되어 매번 불려지는 것도 보안상 괜찮을지 궁금증이 생겼습니다. 그래서 의논하고 싶은 사항이 두가지가 생겼어용
1. 회원 단건 조회시 유저의 핸드폰 번호나 주소같은 개인정보까지 조회하는 api와 상품 상세페이지 같은 곳에서 필요한 유저레벨이나 평점같은 간단 정보만 조회하는 api를 따로 분류해서 만들지 않아도 괜찮을까요?!
2. 비밀번호 컬럼을 지울지 말지, 소셜 로그인쪽 개발하면서 더 확실시되면 이에대해 더 결정하도록 할까용??