### PR TITLE
Exchange에서 acceptorProduct&requesterProduct @JsonIgnore 제거

### DIFF
--- a/src/main/java/hidn/navada/exchange/Exchange.java
+++ b/src/main/java/hidn/navada/exchange/Exchange.java
@@ -27,7 +27,7 @@ public class Exchange extends BaseTime {
     @JoinColumn(referencedColumnName = "userId",name = "acceptorId",nullable = false)
     private User acceptor;                  //교환수락자(fk)
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(referencedColumnName = "productId",name = "acceptorProductId",nullable = false)
     private Product acceptorProduct;        //수락자상품(fk)
 
@@ -35,7 +35,7 @@ public class Exchange extends BaseTime {
     @JoinColumn(referencedColumnName = "userId",name = "requesterId",nullable = false)
     private User requester;                 //교환신청자(fk)
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(referencedColumnName = "productId",name = "requesterProductId",nullable = false)
     private Product requesterProduct;       //신청자상품(fk)
 

--- a/src/main/java/hidn/navada/exchange/Exchange.java
+++ b/src/main/java/hidn/navada/exchange/Exchange.java
@@ -27,7 +27,7 @@ public class Exchange extends BaseTime {
     @JoinColumn(referencedColumnName = "userId",name = "acceptorId",nullable = false)
     private User acceptor;                  //교환수락자(fk)
 
-    @JsonIgnore @ManyToOne(fetch = LAZY)
+    @ManyToOne
     @JoinColumn(referencedColumnName = "productId",name = "acceptorProductId",nullable = false)
     private Product acceptorProduct;        //수락자상품(fk)
 
@@ -35,7 +35,7 @@ public class Exchange extends BaseTime {
     @JoinColumn(referencedColumnName = "userId",name = "requesterId",nullable = false)
     private User requester;                 //교환신청자(fk)
 
-    @JsonIgnore @ManyToOne(fetch = LAZY)
+    @ManyToOne
     @JoinColumn(referencedColumnName = "productId",name = "requesterProductId",nullable = false)
     private Product requesterProduct;       //신청자상품(fk)
 


### PR DESCRIPTION
모바일에서 교환중/교환완료 조회시 acceptor와 requester의 물품정보가 같이 리스트아이템에 계속 포함되어 보여져야 해서 일단 JsonIgnore을 제거하고 모바일에서 작업을 진행했습니다! FetchType.Lazy는 다음과 같은 에러(#35 )가 발생하여 일단 지워놓았습니다. 제가 잘못 안 것이나 더 좋은 의견있으면 얼마든지 알려주시면 감사하겠습니당ㅎㅎㅎ❤️❤️❤️