### PR TITLE
Sprint18 minji

### DIFF
--- a/src/main/java/hidn/navada/comm/ExceptionAdvice.java
+++ b/src/main/java/hidn/navada/comm/ExceptionAdvice.java
@@ -128,6 +128,13 @@ public class ExceptionAdvice {
                 getMessage("duplicatedRequestException.msg"));
     }
 
+    @ExceptionHandler(CanNotCancelExchangeException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    protected CommonResponse CanNotCancelExchangeException(HttpServletRequest request, CanNotCancelExchangeException e){
+        return responseService.getErrorResponse(Integer.parseInt(getMessage("canNotCancelExchangeException.code")),
+                getMessage("canNotCancelExchangeException.msg"));
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     protected CommonResponse MethodArgumentNotValidException(HttpServletRequest request, MethodArgumentNotValidException e){

--- a/src/main/java/hidn/navada/comm/exception/CanNotCancelExchangeException.java
+++ b/src/main/java/hidn/navada/comm/exception/CanNotCancelExchangeException.java
@@ -1,0 +1,5 @@
+package hidn.navada.comm.exception;
+
+public class CanNotCancelExchangeException extends RuntimeException{
+    public CanNotCancelExchangeException(){super();}
+}

--- a/src/main/java/hidn/navada/exchange/Exchange.java
+++ b/src/main/java/hidn/navada/exchange/Exchange.java
@@ -62,4 +62,8 @@ public class Exchange extends BaseTime {
 
     @ColumnDefault("false") @Builder.Default
     private boolean requesterHistoryDeleteYn=false;     //requester의 거래내역 삭제 여부
+
+    @Column(columnDefinition="char default 1")
+    @Builder.Default
+    private char exchangeStatusCd='1';   // 교환 상태(1: 교환중, 2: 교환완료, 3: 교환취소)
 }

--- a/src/main/java/hidn/navada/exchange/ExchangeController.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeController.java
@@ -40,4 +40,11 @@ public class ExchangeController {
     public SingleResponse<Exchange> deleteExchangeHistory(@PathVariable Long exchangeId, @RequestParam Boolean isAcceptor){
         return responseService.getSingleResponse(exchangeService.deleteExchangeHistory(exchangeId, isAcceptor));
     }
+
+    // 교환 취소
+    @PatchMapping(value = "/exchange/{exchangeId}/cancel")
+    public SingleResponse<Exchange> cancelExchange(@PathVariable Long exchangeId){
+        return responseService.getSingleResponse(exchangeService.cancelExchange(exchangeId));
+    }
+
 }

--- a/src/main/java/hidn/navada/exchange/request/RequestService.java
+++ b/src/main/java/hidn/navada/exchange/request/RequestService.java
@@ -72,6 +72,9 @@ public class RequestService {
         // requester 가 신청한 나머지 교환 신청들 삭제
         rejectRequestsByRequester(requesterProduct);
 
+        //교환 신청 삭제
+        requestJpaRepo.deleteById(requestId);
+
         // Exchange 엔티티 생성
         return exchangeService.createExchange(request);
     }

--- a/src/main/java/hidn/navada/product/ProductJpaRepo.java
+++ b/src/main/java/hidn/navada/product/ProductJpaRepo.java
@@ -15,8 +15,17 @@ public interface ProductJpaRepo extends JpaRepository<Product, Long> {
     @Query(value = "select * from Product p where (:#{#options.productName} is null or p.product_name like :#{#options.productName}) " +
             "and (coalesce(:#{#options.categoryIds},null) is null or p.category_id in (:#{#options.categoryIds})) " +
             "and (:#{#options.lowerCostBound} is null or (:#{#options.lowerCostBound} <= p.product_cost)) " +
-            "and (:#{#options. upperCostBound} is null or (p.product_cost <= :#{#options.upperCostBound})) ",nativeQuery = true)
+            "and (:#{#options. upperCostBound} is null or (p.product_cost <= :#{#options.upperCostBound})) "+
+            "and (coalesce(:#{#options.productExchangeStatusCds},null) is null or p.product_exchange_status_cd in (:#{#options.productExchangeStatusCds}))",nativeQuery = true)
     Page<Product> findProductsByOptions(@Param("options") ProductSearchOptions options, Pageable pageable);
+
+    @Query(value = "select * from Product p where (:#{#options.productName} is null or p.product_name like :#{#options.productName}) " +
+            "and (coalesce(:#{#options.categoryIds},null) is null or p.category_id in (:#{#options.categoryIds})) " +
+            "and (:#{#options.lowerCostBound} is null or (:#{#options.lowerCostBound} <= p.product_cost)) " +
+            "and (:#{#options. upperCostBound} is null or (p.product_cost <= :#{#options.upperCostBound})) "+
+            "and (coalesce(:#{#options.productExchangeStatusCds},null) is null or p.product_exchange_status_cd in(:#{#options.productExchangeStatusCds})) "+
+            "and p.user_id != :userId",nativeQuery = true)
+    Page<Product> findProductsByOptionsExceptMyProduct(@Param("options") ProductSearchOptions options, @Param("userId") long userId,Pageable pageable);
 
 
     @Query(value = "select h.product.productId from Heart h where h.user=:user")

--- a/src/main/java/hidn/navada/product/ProductSearchOptions.java
+++ b/src/main/java/hidn/navada/product/ProductSearchOptions.java
@@ -14,4 +14,6 @@ public class ProductSearchOptions {
     private List<Long> categoryIds;
     private Integer lowerCostBound;
     private Integer upperCostBound;
+    private Boolean isMyProductIncluded;    // 내 상품 포함해서 보기
+    private List<Long> productExchangeStatusCds;    // 상태
 }

--- a/src/main/java/hidn/navada/product/ProductService.java
+++ b/src/main/java/hidn/navada/product/ProductService.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
-
 @Slf4j
 @Service
 @Transactional
@@ -116,7 +115,10 @@ public class ProductService {
 
         if (productSearchOptions.getProductName()!=null)
             productSearchOptions.setProductName('%'+productSearchOptions.getProductName()+'%');
-        Page<Product> products = productJpaRepo.findProductsByOptions(productSearchOptions,pageable);
+
+        Page<Product> products = productSearchOptions.getIsMyProductIncluded()
+                ? productJpaRepo.findProductsByOptions(productSearchOptions,pageable)
+                : productJpaRepo.findProductsByOptionsExceptMyProduct(productSearchOptions,userId,pageable);
 
         Page<ProductSearchDto> result = products.map(product -> new ProductSearchDto(product,likeProductIds.contains(product.getProductId())));
         return result;

--- a/src/main/resources/i18n/exception_en.yml
+++ b/src/main/resources/i18n/exception_en.yml
@@ -43,4 +43,7 @@ tokenValidationException:
 duplicatedRequestException:
   code: "400"
   msg: "Request duplicated."
+canNotCancelExchangeException:
+  code: "400"
+  msg: "Can not cancel this exchange."
 

--- a/src/main/resources/i18n/exception_ko.yml
+++ b/src/main/resources/i18n/exception_ko.yml
@@ -43,3 +43,6 @@ tokenValidationException:
 duplicatedRequestException:
   code: "400"
   msg: "이미 존재하는 교환신청입니다."
+canNotCancelExchangeException:
+  code: "400"
+  msg: "한쪽이라도 교환완료한 경우, 해당 교환은 삭제할 수 없습니다."


### PR DESCRIPTION
- 검색 api : 내상품만 보기 , 상품상태별 보기
- 교환 취소 api
- 교환 수락 시 해당 교환 신청 삭제

위 3가지 기능 추가했습니다!

- exchangeCompleteYn 의 경우 모바일에서 어느부분에 쓰이고 있는지 몰라서 그냥 바로 삭제해버리면 안될것같아 일단 그냥 두었습니다
- 토의필요항목에도 적어놓았는데 , exchangeStatusCd 를 기존의 Product에서 쓰던 (1. 교환중, 2. 교환완료) 와 달리 (0. 교환중, 1. 교환완료) 로 정해두었더니 개인적으로는 조금 헷갈리는것같아서요.. 0번을 비우고 1,2 는 항상 교환중/교환완료 로 통일하면 어떨까 싶은데 이부분은 토의 후에 결정되면 수정하던가 하겠습니다!