### PR TITLE
exchangeCompleteYn 제거, 사용자별 상품목록조회 수정

### DIFF
--- a/src/main/java/hidn/navada/exchange/Exchange.java
+++ b/src/main/java/hidn/navada/exchange/Exchange.java
@@ -46,9 +46,6 @@ public class Exchange extends BaseTime {
     @ColumnDefault("false") @Builder.Default
     private boolean requesterConfirmYn=false;           //신청자 확인여부
 
-    @ColumnDefault("false") @Builder.Default
-    private boolean exchangeCompleteYn=false;           //교환완료여부
-
     private LocalDateTime exchangeCompleteDt;           //교환완료일시
 
     @ColumnDefault("-1") @Builder.Default

--- a/src/main/java/hidn/navada/exchange/ExchangeController.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeController.java
@@ -25,7 +25,7 @@ public class ExchangeController {
     // 교환 목록 조회(교환중, 교환완료)
     @GetMapping(value = "/user/{userId}/exchanges")
     public PageResponse<ExchangeDto> getExchangeList(@PathVariable Long userId, @RequestParam(required = false) Boolean viewOnlySentElseGot,
-                                                     @PageableDefault(size =20, sort = "exchangeCompleteYn") Pageable pageable) {
+                                                     @PageableDefault(size =20, sort = "exchangeStatusCd") Pageable pageable) {
         return responseService.getPageResponse(exchangeService.getExchangeList(userId, viewOnlySentElseGot, pageable));
     }
 

--- a/src/main/java/hidn/navada/exchange/ExchangeController.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeController.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping(value = "/v1")
@@ -22,11 +24,13 @@ public class ExchangeController {
         return responseService.getSingleResponse(exchangeService.completeExchange(exchangeId, isAcceptor));
     }
 
-    // 교환 목록 조회(교환중, 교환완료)
+    // 교환 목록 조회
     @GetMapping(value = "/user/{userId}/exchanges")
-    public PageResponse<ExchangeDto> getExchangeList(@PathVariable Long userId, @RequestParam(required = false) Boolean viewOnlySentElseGot,
+    public PageResponse<ExchangeDto> getExchangeList(@PathVariable Long userId,
+                                                     @RequestParam(required = false) List<Character> exchangeStatusCds,
+                                                     @RequestParam(required = false) Boolean viewOnlySentElseGot,
                                                      @PageableDefault(size =20, sort = "exchangeStatusCd") Pageable pageable) {
-        return responseService.getPageResponse(exchangeService.getExchangeList(userId, viewOnlySentElseGot, pageable));
+        return responseService.getPageResponse(exchangeService.getExchangeList(userId, exchangeStatusCds, viewOnlySentElseGot, pageable));
     }
 
     // 교환상대에게 평점 부여

--- a/src/main/java/hidn/navada/exchange/ExchangeDto.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeDto.java
@@ -27,7 +27,7 @@ public class ExchangeDto {
 
     private Product acceptorProduct;
 
-    private boolean exchangeCompleteYn;
+    private char exchangeStatusCd;
 
     public ExchangeDto(Exchange exchange){
         exchangeId=exchange.getExchangeId();
@@ -39,6 +39,6 @@ public class ExchangeDto {
         acceptorRating = exchange.getAcceptorRating();
         requesterProduct = exchange.getRequesterProduct();
         acceptorProduct = exchange.getAcceptorProduct();
-        exchangeCompleteYn = exchange.isExchangeCompleteYn();
+        exchangeStatusCd = exchange.getExchangeStatusCd();
     }
 }

--- a/src/main/java/hidn/navada/exchange/ExchangeJpaRepo.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeJpaRepo.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ExchangeJpaRepo extends JpaRepository<Exchange, Long> {
@@ -15,20 +16,26 @@ public interface ExchangeJpaRepo extends JpaRepository<Exchange, Long> {
     Optional<Exchange> findByIdWithProduct(@Param("exchangeId") long exchangeId);
 
     @Query(value = "select e from Exchange e join fetch e.requesterProduct join fetch e.acceptorProduct " +
-            "where (e.acceptor=:user and e.acceptorHistoryDeleteYn=false) or (e.requester=:user and e.requesterHistoryDeleteYn=false)",
+            "where ((e.acceptor=:user and e.acceptorHistoryDeleteYn=false) or (e.requester=:user and e.requesterHistoryDeleteYn=false))" +
+            " and (coalesce(:exchangeStatusCds,null) is null or (e.exchangeStatusCd in :exchangeStatusCds))",
     countQuery = "select count(e) from Exchange e inner join e.requesterProduct inner join e.acceptorProduct " +
-            "where (e.acceptor=:user and e.acceptorHistoryDeleteYn=false) or (e.requester=:user and e.requesterHistoryDeleteYn=false)")
-    Page<Exchange> findExchangePagesByUser(@Param("user") User user, Pageable pageable);
+            "where ((e.acceptor=:user and e.acceptorHistoryDeleteYn=false) or (e.requester=:user and e.requesterHistoryDeleteYn=false))" +
+            " and (coalesce(:exchangeStatusCds,null) is null or (e.exchangeStatusCd in :exchangeStatusCds))")
+    Page<Exchange> findExchangePagesByUser(@Param("user") User user, @Param("exchangeStatusCds") List<Character> exchangeStatusCds, Pageable pageable);
 
     @Query(value = "select e from Exchange e join fetch e.requesterProduct join fetch e.acceptorProduct " +
-            "where (e.requester=:user and e.requesterHistoryDeleteYn=false)",
+            "where (e.requester=:user and e.requesterHistoryDeleteYn=false)" +
+            " and (coalesce(:exchangeStatusCds,null) is null or (e.exchangeStatusCd in :exchangeStatusCds))",
     countQuery = "select count(e) from Exchange e inner join e.requesterProduct inner join e.acceptorProduct " +
-            "where (e.requester=:user and e.requesterHistoryDeleteYn=false)")
-    Page<Exchange> findExchangePagesByRequester(@Param("user") User user, Pageable pageable);
+            "where (e.requester=:user and e.requesterHistoryDeleteYn=false)" +
+            " and (coalesce(:exchangeStatusCds,null) is null or (e.exchangeStatusCd in :exchangeStatusCds))")
+    Page<Exchange> findExchangePagesByRequester(@Param("user") User user, @Param("exchangeStatusCds") List<Character> exchangeStatusCds, Pageable pageable);
 
     @Query(value = "select e from Exchange e join fetch e.acceptorProduct join fetch e.requesterProduct " +
-            "where (e.acceptor=:user and e.acceptorHistoryDeleteYn=false)",
+            "where (e.acceptor=:user and e.acceptorHistoryDeleteYn=false)" +
+            " and (coalesce(:exchangeStatusCds,null) is null or (e.exchangeStatusCd in :exchangeStatusCds))",
     countQuery ="select count(e) from Exchange e inner join e.acceptorProduct inner join e.requesterProduct " +
-            "where (e.acceptor=:user and e.acceptorHistoryDeleteYn=false)" )
-    Page<Exchange> findExchangePagesByAcceptor(@Param("user") User user, Pageable pageable);
+            "where (e.acceptor=:user and e.acceptorHistoryDeleteYn=false)" +
+            " and (coalesce(:exchangeStatusCds,null) is null or (e.exchangeStatusCd in :exchangeStatusCds))" )
+    Page<Exchange> findExchangePagesByAcceptor(@Param("user") User user, @Param("exchangeStatusCds") List<Character> exchangeStatusCds, Pageable pageable);
 }

--- a/src/main/java/hidn/navada/exchange/ExchangeService.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeService.java
@@ -16,6 +16,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @Transactional
@@ -88,16 +89,16 @@ public class ExchangeService {
     }
 
     //교환목록조회(교환중, 교환완료)
-    public Page<ExchangeDto> getExchangeList(Long userId, Boolean viewOnlySentElseGot, Pageable pageable) {
+    public Page<ExchangeDto> getExchangeList(Long userId, List<Character> exchangeStatusCds, Boolean viewOnlySentElseGot, Pageable pageable) {
         User user = userJpaRepo.findById(userId).orElseThrow(UserNotFoundException::new);
         Page<Exchange> exchanges;
 
         if(viewOnlySentElseGot == null)
-            exchanges = exchangeJpaRepo.findExchangePagesByUser(user, pageable);
+            exchanges = exchangeJpaRepo.findExchangePagesByUser(user, exchangeStatusCds, pageable);
         else {
             exchanges = (viewOnlySentElseGot)
-                    ? exchangeJpaRepo.findExchangePagesByRequester(user, pageable)
-                    : exchangeJpaRepo.findExchangePagesByAcceptor(user, pageable);
+                    ? exchangeJpaRepo.findExchangePagesByRequester(user, exchangeStatusCds, pageable)
+                    : exchangeJpaRepo.findExchangePagesByAcceptor(user, exchangeStatusCds, pageable);
         }
         return convertToDto(exchanges);
     }

--- a/src/main/java/hidn/navada/exchange/ExchangeService.java
+++ b/src/main/java/hidn/navada/exchange/ExchangeService.java
@@ -46,7 +46,6 @@ public class ExchangeService {
 
         // 둘다 교환 완료인 경우
         if(exchange.isAcceptorConfirmYn() && exchange.isRequesterConfirmYn()) {
-            exchange.setExchangeCompleteYn(true);
             exchange.setExchangeStatusCd('2'); //2. 교환 완료
             exchange.setExchangeCompleteDt(LocalDateTime.now());
 

--- a/src/main/java/hidn/navada/product/ProductController.java
+++ b/src/main/java/hidn/navada/product/ProductController.java
@@ -31,8 +31,8 @@ public class ProductController {
 
     //사용자별 상품 리스트 조회
     @GetMapping(value = "/user/{userId}/products")
-    public PageResponse<Product> getProductsByUser(@PathVariable long userId, @PageableDefault(size = 20)Pageable pageable){
-        return responseService.getPageResponse(productService.getProductsByUser(userId,pageable));
+    public PageResponse<Product> getProductsByUser(@PathVariable long userId, @RequestParam(required = false) List<Character> productExchangeStatusCds, @PageableDefault(size = 20)Pageable pageable){
+        return responseService.getPageResponse(productService.getProductsByUser(userId,productExchangeStatusCds,pageable));
     }
 
     // 내물품 리스트 조회(교환 신청하기 화면에서 상대방에게 이미 신청했는지 체크위해 사용)

--- a/src/main/java/hidn/navada/product/ProductJpaRepo.java
+++ b/src/main/java/hidn/navada/product/ProductJpaRepo.java
@@ -10,7 +10,9 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ProductJpaRepo extends JpaRepository<Product, Long> {
-    Page<Product> findProductsByUser(User user, Pageable pageable);
+    @Query(value = "select p from Product p where p.user=:user" +
+            " and (coalesce(:productExchangeStatusCds,null) is null or (p.productExchangeStatusCd in :productExchangeStatusCds))")
+    Page<Product> findProductsByUser(@Param("user") User user, @Param("productExchangeStatusCds") List<Character> productExchangeStatusCds, Pageable pageable);
 
     @Query(value = "select * from Product p where (:#{#options.productName} is null or p.product_name like :#{#options.productName}) " +
             "and (coalesce(:#{#options.categoryIds},null) is null or p.category_id in (:#{#options.categoryIds})) " +

--- a/src/main/java/hidn/navada/product/ProductService.java
+++ b/src/main/java/hidn/navada/product/ProductService.java
@@ -66,10 +66,10 @@ public class ProductService {
 
 
     //사용자별 상품 리스트 조회
-    public Page<Product> getProductsByUser(long userId, Pageable pageable){
+    public Page<Product> getProductsByUser(long userId, List<Character> productExchangeStatusCds, Pageable pageable){
         User user= userJpaRepo.findById(userId).orElseThrow(UserNotFoundException::new);
 
-        return productJpaRepo.findProductsByUser(user,pageable);
+        return productJpaRepo.findProductsByUser(user, productExchangeStatusCds, pageable);
     }
 
 


### PR DESCRIPTION
모바일에서 exchangeStatusCd로 수정하면서 백엔드 DTO 부분도 exchangeStatusCd로 수정했습니다 
exchangeCompleteYn은 이제 모두 제거되었습니다! 

그리고 피그마기획을 보니 상품목록 조회 api에 상품상태코드가 추가되어야할 것 같아서 추가해놓았습니다!